### PR TITLE
Add test and travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+    - "3.3"
+    - "3.4"
+
+env:
+    - DJANGO_VERSION=1.8
+
+install:
+    - python3 -m pip install -q Django==$DJANGO_VERSION
+    - python3 -m pip install pytest
+    - python3 -m pip install pytest-django
+
+script:
+    - python3 -m pytest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # contributr
 An online tool for programmers to find projects they can contribute to and project maintainers to find contributors. 
+
+[![Build Status](https://travis-ci.org/tobias47n9e/contributr.svg)](https://travis-ci.org/tobias47n9e/contributr)

--- a/contributr/test_module/test_admin.py
+++ b/contributr/test_module/test_admin.py
@@ -1,0 +1,14 @@
+import pytest
+
+@pytest.mark.django_db
+def test_welcome_django(admin_client):
+    """
+    Asserts whether the admin page sends a 200 HTTP status code as response
+
+    200 means that the HTTP request was successful. Tests for the admin
+    pages are done with the admin_client. The URL and port may vary. The
+    fixture above the function allows the function to access the database.
+    """
+    response = admin_client.get("http://localhost:8000/admin/")
+    assert response.status_code == 200
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=contributr.settings


### PR DESCRIPTION
This PR includes 1 test for the admin interface and the pytest.ini file. The Travis-CI file runs tests using Python 3.3 and 3.4 (3.5-dev failed probably because Django is not compatible yet). I only put in tests against 1.8 because I don't think we need to stay backwards compatible with a new project.

The repository still has to be enabled on the Travis website. Then the build status tag has to get the new URL.
