### PR TITLE
load SECRET_KEY from environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,12 @@ cache:
 
 # set environmental variables for project
 env:
+  matrix:
     # django
     - DJANGO_VERSION=1.8 DJANGO_SETTINGS_MODULE="contributr/settings"
+  global:
+    # Note: This key only used for development and testing.
+    - SECRET_KEY="s#9i93akev%vr99xd^zcalfvt*ru6*q)c+anowu($9ba*&-)8y"
 
 # install dependencies and any other requirements before running tests
 install:

--- a/contributr/contributr/settings.py
+++ b/contributr/contributr/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -20,7 +21,16 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'djkk&8izc3tmgva(m$%u_zvjk8%f@-6w(d-z68@m-@sh3nz#pi'
+
+# Loads SECRET_KEY from environment variable SECRET_KEY
+def get_env_variable(var_name):
+    try:
+        return os.environ[var_name]
+    except KeyError:
+        error_msg = "Set the %s environment variable" % var_name
+        raise ImproperlyConfigured(error_msg)
+
+SECRET_KEY = get_env_variable('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Django's `SECRET_KEY` in `settings.py` file is not supposed to be exposed in the source code. Here it is loaded from the environment key `SECRET_KEY`

To set your SECRET_KEY do:

``` bash
export SECRET_KEY="your_secret_django_key"
```

in your terminal.
