### PR TITLE
add test for base URL

### DIFF
--- a/contributr/contributr/test_module/test_views.py
+++ b/contributr/contributr/test_module/test_views.py
@@ -1,0 +1,13 @@
+import pytest
+
+@pytest.mark.django_db
+def test_welcome_django(client):
+    """
+    Asserts whether the base URL 404s
+
+    404 means that the HTTP request could not reach a page. We don't have a
+    page yet, so 404 is the expected return.
+    """
+    response = client.get("http://localhost:8000/")
+    assert response.status_code == 404
+


### PR DESCRIPTION
Created a test_views.py file in the test_module folder. The test grabs the base URL using the standard client and checks the return code. Because there is no page yet, the assertion looks for a 404 code. This PR resolves issue https://github.com/Djenesis/contributr/issues/14.
