### PR TITLE
properly get SECRET_KEY

### DIFF
--- a/contributr/contributr/settings.py
+++ b/contributr/contributr/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -23,14 +22,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 
 # Loads SECRET_KEY from environment variable SECRET_KEY
-def get_env_variable(var_name):
-    try:
-        return os.environ[var_name]
-    except KeyError:
-        error_msg = "Set the %s environment variable" % var_name
-        raise ImproperlyConfigured(error_msg)
-
-SECRET_KEY = get_env_variable('SECRET_KEY')
+SECRET_KEY = os.environ.get('SECRET_KEY', None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
#17

use os.environ.get() to fetch SECRET_KEY env variable. If SECRET_KEY
is not present, then SECRET_KEY is set to None, on which Django
raises a ImproperlyConfigured exception.
