### PR TITLE
Travis secret key env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ env:
   matrix:
     # django
     - DJANGO_VERSION=1.8 DJANGO_SETTINGS_MODULE="contributr.settings"
-  global:
-    # Note: This key only used for development and testing.
-    - SECRET_KEY="s#9i93akev%vr99xd^zcalfvt*ru6*q)c+anowu($9ba*&-)8y"
 
 # install dependencies and any other requirements before running tests
 install:


### PR DESCRIPTION
The `SECRET_KEY` var in Travis web settings can be used, which I have configured in the following format: 'string' (single-quotes). Following this, I've removed the `SECRET_KEY` settings from `.travis.yml`
