### PR TITLE
Add path to updated local settings file

### DIFF
--- a/contributr/manage.py
+++ b/contributr/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "contributr.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "contributr.settings.local")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
When pull request #34 was merged, it broke manage.py because it didn't point the DJANGO_SETTINGS_MODULE environment variable to new updated local settings file.
