### PR TITLE
Heroku configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --pythonpath contributr contributr.wsgi --log-file -

--- a/contributr/contributr/settings/production.py
+++ b/contributr/contributr/settings/production.py
@@ -2,5 +2,26 @@
 # This file contains settings for the Heroku production server
 
 from .base import *
+import os
 
-DEBUG = False
+# Parse database configuration from $DATABASE_URL in heroku environment
+import dj_database_url
+DATABASES['default'] = dj_database_url.config()
+
+# Honor the 'X-Forwarded-Proto' header for request.is_secure()
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+# Allow all host headers
+ALLOWED_HOSTS = ['*']
+
+# Static asset configuration
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STATIC_ROOT = 'staticfiles'
+STATIC_URL = '/static/'
+
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, 'static'),
+)
+
+DEBUG = True

--- a/contributr/contributr/wsgi.py
+++ b/contributr/contributr/wsgi.py
@@ -10,7 +10,10 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from dj_static import Cling
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "contributr.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "contributr.settings.local")
 
-application = get_wsgi_application()
+# Cling is a simple way of serving static assets.
+# http://www.kennethreitz.org/essays/introducing-dj-static
+application = Cling(get_wsgi_application())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r requirements/requirements_prod.txt

--- a/requirements/requirements_prod.in
+++ b/requirements/requirements_prod.in
@@ -2,3 +2,8 @@
 # dependencies for production
 
 Django
+dj-database-url
+dj-static
+gunicorn
+psycopg2
+static

--- a/requirements/requirements_prod.txt
+++ b/requirements/requirements_prod.txt
@@ -4,4 +4,11 @@
 #
 #    pip-compile requirements_prod.in
 #
+dj-database-url==0.3.0
+dj-static==0.0.6
 django==1.8.4
+gunicorn==19.3.0
+psycopg2==2.6.1
+pystache==0.5.4           # via static
+static3==0.6.1            # via dj-static
+static==1.1.1


### PR DESCRIPTION
This adds the configuration for a development server located at
http://contributr.herokuapp.com.

It uses the production settings at contributr.settings.production
set by the DJANGO_SETTINGS_MODULE environment variable.

The requirements and wsgi configuration required in heroku's
environment are added.

Procfile and requirements should be there in the root of our
project, so a --pythonpath is required for gunicorn to go in the
right path and find the wsgi file. Also, a production requirements
file is loaded from requirements.txt
