### PR TITLE
Move production Cling settings into production-only block

### DIFF
--- a/contributr/contributr/wsgi.py
+++ b/contributr/contributr/wsgi.py
@@ -10,10 +10,13 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
-from dj_static import Cling
+
+if os.environ.get("DJANGO_SETTINGS_MODULE") == "contributr.settings.production":
+    # Cling is a simple way of serving static assets.
+    # http://www.kennethreitz.org/essays/introducing-dj-static
+    from dj_static import Cling
+    application = Cling(get_wsgi_application())
+else:
+    application = get_wsgi_application()
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "contributr.settings.local")
-
-# Cling is a simple way of serving static assets.
-# http://www.kennethreitz.org/essays/introducing-dj-static
-application = Cling(get_wsgi_application())


### PR DESCRIPTION
The Cling import and call are moved into an if-block that is only
executed when the server is run with production settings. This
makes the server run locally again.

Resolves: #42
