### PR TITLE
Add Post model for basic blog data

### DIFF
--- a/contributr/contriblog/admin.py
+++ b/contributr/contriblog/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Post
+
+
+admin.site.register(Post)

--- a/contributr/contriblog/migrations/0001_initial.py
+++ b/contributr/contriblog/migrations/0001_initial.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Post',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=300)),
+                ('body', models.TextField()),
+                ('created_date', models.DateTimeField(auto_now_add=True)),
+                ('modified_date', models.DateTimeField(auto_now=True)),
+                ('published_date', models.DateTimeField()),
+                ('author', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/contributr/contriblog/models.py
+++ b/contributr/contriblog/models.py
@@ -1,3 +1,13 @@
 from django.db import models
 
-# Create your models here.
+
+class Post(models.Model):
+    title = models.CharField(max_length=300)
+    author = models.ForeignKey('auth.User')
+    body = models.TextField()
+    created_date = models.DateTimeField(auto_now_add=True)
+    modified_date = models.DateTimeField(auto_now=True)
+    published_date = models.DateTimeField()
+
+    def __str__(self):
+        return self.title

--- a/contributr/contriblog/tests/test_blog.py
+++ b/contributr/contriblog/tests/test_blog.py
@@ -1,6 +1,7 @@
 import pytest
 
 from django.core.urlresolvers import reverse
+from contriblog.models import Post
 
 @pytest.mark.django_db
 def test_call_blog(client):
@@ -24,3 +25,12 @@ def test_call_blog_subpage(client):
     """
     response = client.get(reverse("blog:index") + "december")
     assert response.status_code == 404
+
+@pytest.mark.django_db
+def test_string_representation(client):
+    """
+    Asserts wether the blog post string representation (__str__) is equal 
+    to the blog title.
+    """
+    post = Post(title="Test title blog")
+    assert str(post) == "Test title blog"


### PR DESCRIPTION
This is a Post model for basic data for a blog. This includes, title, author, body, created date, modified date and published date. The field author has a foreignkey relationship with the user model. created_date has a field option of auto_now_add which sets the date automatically when created. modified_date has the field option auto_now which sets the field to now every time the post is saved. Also registered the Post model to the admin site interface, so posts can be created, edited and deleted.

Added a test for string representation. This test if the string representation in Posts is equal to the
blog title.
