### PR TITLE
Update blog model and add basic views and templates

### DIFF
--- a/contributr/contriblog/admin.py
+++ b/contributr/contriblog/admin.py
@@ -3,4 +3,9 @@ from django.contrib import admin
 from .models import Post
 
 
-admin.site.register(Post)
+class PostAdmin(admin.ModelAdmin):
+    prepopulated_fields = {'slug':('title',)}
+    list_display = ('title', 'author', 'created_date',)
+
+
+admin.site.register(Post, PostAdmin)

--- a/contributr/contriblog/migrations/0001_initial.py
+++ b/contributr/contriblog/migrations/0001_initial.py
@@ -15,13 +15,19 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Post',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('title', models.CharField(max_length=300)),
+                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
+                ('title', models.CharField(max_length=200)),
                 ('body', models.TextField()),
                 ('created_date', models.DateTimeField(auto_now_add=True)),
-                ('modified_date', models.DateTimeField(auto_now=True)),
-                ('published_date', models.DateTimeField()),
+                ('edited_date', models.DateTimeField(auto_now=True)),
+                ('publish', models.BooleanField(default=False)),
+                ('slug', models.SlugField(unique=True, max_length=200)),
                 ('author', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
+            options={
+                'verbose_name_plural': 'Blog posts',
+                'verbose_name': 'Blog post',
+                'ordering': ['-created_date'],
+            },
         ),
     ]

--- a/contributr/contriblog/models.py
+++ b/contributr/contriblog/models.py
@@ -1,13 +1,33 @@
 from django.db import models
 
+from django.core.urlresolvers import reverse
+
+
+# Custom queryset manager that only displays posts that have publish set to true.
+class PostQuerySet(models.QuerySet):
+
+    def published(self):
+        return self.filter(publish=True)
+
 
 class Post(models.Model):
-    title = models.CharField(max_length=300)
+    title = models.CharField(max_length=200)
     author = models.ForeignKey('auth.User')
     body = models.TextField()
     created_date = models.DateTimeField(auto_now_add=True)
-    modified_date = models.DateTimeField(auto_now=True)
-    published_date = models.DateTimeField()
+    edited_date = models.DateTimeField(auto_now=True)
+    publish = models.BooleanField(default=False)
+    slug = models.SlugField(max_length=200, unique=True)
+
+    objects = PostQuerySet.as_manager()
+
+    def get_absolute_url(self):
+        return reverse('blog:detail', kwargs={'slug': self.slug})
 
     def __str__(self):
         return self.title
+
+    class Meta:
+        verbose_name = "Blog post"
+        verbose_name_plural = "Blog posts"
+        ordering = ["-created_date"]

--- a/contributr/contriblog/templates/contriblog/detail.html
+++ b/contributr/contriblog/templates/contriblog/detail.html
@@ -1,0 +1,13 @@
+<html>
+<head><title>Contriblog</title></head>
+<body>
+
+<h1>Contributr blog</h1>
+  <h3>{{ object.title }}</h3> 
+  <p>Created: {{object.created_date|date }}</p>
+  <p>Last edited: {{ object.edited_date|date }}</p>
+  <p>Author: {{ object.author }}</p>
+  <p>{{ object.body }}</p>
+
+</body>
+</html>

--- a/contributr/contriblog/templates/contriblog/index.html
+++ b/contributr/contriblog/templates/contriblog/index.html
@@ -1,0 +1,17 @@
+<html>
+<head><title>Contriblog</title></head>
+<body>
+
+<h1>Contributr blog</h1>
+{% for object in object_list %}
+  <h3>{{ object.title }}</h3> 
+  <p>Created: {{object.created_date }}</p>
+  <p>Last edited: {{ object.edited_date|date }}</p>
+  <p>Author: {{ object.author }}</p>
+  <p>{{ object.body }}</p>
+  <p><a href=" {% url "blog:detail" slug=object.slug %} ">Permalink</a></p>
+  <hr>
+{% endfor %}
+
+</body>
+</html>

--- a/contributr/contriblog/tests/test_blog.py
+++ b/contributr/contriblog/tests/test_blog.py
@@ -1,7 +1,9 @@
 import pytest
 
 from django.core.urlresolvers import reverse
+from django.contrib.auth import get_user_model
 from contriblog.models import Post
+
 
 @pytest.mark.django_db
 def test_call_blog(client):
@@ -26,11 +28,29 @@ def test_call_blog_subpage(client):
     response = client.get(reverse("blog:index") + "december")
     assert response.status_code == 404
 
+
 @pytest.mark.django_db
-def test_string_representation(client):
+def test_blog_model():
     """
-    Asserts wether the blog post string representation (__str__) is equal 
+    Create a user and a blog post with publish set to false.
+    Then assert that number of blog posts equals 1.
+    """
+    user = get_user_model().objects.create(username="bloghero")
+    post = Post(title="Test title blog", author=user, body="Blogging here!", publish=False)
+    post.save()
+    assert Post.objects.all().count() == 1
+
+    """
+    Assert that the custom queryset displays posts that has publish 
+    set to true.
+    """
+    assert Post.objects.published().count() == 0
+    post.publish = True
+    post.save()
+    assert Post.objects.published().count() == 1
+
+    """
+    Asserts wether the post string representation (__str__) is equal 
     to the blog title.
     """
-    post = Post(title="Test title blog")
     assert str(post) == "Test title blog"

--- a/contributr/contriblog/urls.py
+++ b/contributr/contriblog/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import url
 
 from . import views
 
+
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
+    url(r'^$', views.BlogIndex.as_view(), name="index"),
+    url(r'^post/(?P<slug>\S+)$', views.BlogDetail.as_view(), name="detail"),
     ]

--- a/contributr/contriblog/views.py
+++ b/contributr/contriblog/views.py
@@ -1,4 +1,15 @@
-from django.http import HttpResponse
+from django.views import generic
 
-def index(request):
-    return HttpResponse("I am a blog.")
+from . import models
+
+
+# Generic view that lists all blog posts that has publish set to true.
+class BlogIndex(generic.ListView):
+    queryset = models.Post.objects.published()
+    template_name = "contriblog/index.html"
+
+
+# Generic view that displays each post.
+class BlogDetail(generic.DetailView):
+    model = models.Post
+    template_name = "contriblog/detail.html"


### PR DESCRIPTION
- Custom queryset manager, PostQuerySet. This filters and only displays posts that has publish set to true. This makes it easy to create blog drafts, and to publish only when it's done. See https://docs.djangoproject.com/en/1.8/topics/db/managers/#calling-custom-queryset-methods-from-the-manager
- Meta class for verbose name and a plural name in the admin. Also set the blog post ordering in reverse chronological order with -created_date, so the latest post is displayed first.
- Slugfield, for a user friendly url to each post.
- PostAdmin to lists fields with title, author and created date in the admin. Also added a prepopulated field which automatically fills the slug with javascript.
- Basic templates and class based generic views for the blog.
- Some tests to assert that the custom queryset displays posts that has publish set to true.
  Closes #54
