### PR TITLE
Add markdown support for the blog

### DIFF
--- a/contributr/contriblog/templates/contriblog/detail.html
+++ b/contributr/contriblog/templates/contriblog/detail.html
@@ -1,13 +1,14 @@
+{% load markdown_deux_tags %}
 <html>
 <head><title>Contriblog</title></head>
 <body>
 
 <h1>Contributr blog</h1>
   <h3>{{ object.title }}</h3> 
-  <p>Created: {{object.created_date|date }}</p>
+  <p>Created: {{ object.created_date|date }}</p>
   <p>Last edited: {{ object.edited_date|date }}</p>
   <p>Author: {{ object.author }}</p>
-  <p>{{ object.body }}</p>
+  <p>{{ object.body|markdown }}</p>
 
 </body>
 </html>

--- a/contributr/contriblog/templates/contriblog/index.html
+++ b/contributr/contriblog/templates/contriblog/index.html
@@ -1,3 +1,4 @@
+{% load markdown_deux_tags %}
 <html>
 <head><title>Contriblog</title></head>
 <body>
@@ -5,11 +6,11 @@
 <h1>Contributr blog</h1>
 {% for object in object_list %}
   <h3>{{ object.title }}</h3> 
-  <p>Created: {{object.created_date }}</p>
+  <p>Created: {{ object.created_date }}</p>
   <p>Last edited: {{ object.edited_date|date }}</p>
   <p>Author: {{ object.author }}</p>
-  <p>{{ object.body }}</p>
-  <p><a href=" {% url "blog:detail" slug=object.slug %} ">Permalink</a></p>
+  <p>{{ object.body|markdown }}</p>
+  <p><a href="{% url "blog:detail" slug=object.slug %}">Permalink</a></p>
   <hr>
 {% endfor %}
 

--- a/contributr/contributr/settings/base.py
+++ b/contributr/contributr/settings/base.py
@@ -32,12 +32,18 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = (
+    # Django applications
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
+    # Third party applications
+    'markdown_deux',
+
+    # Project applications
     'contriblog',
 )
 

--- a/requirements/requirements_dev.in
+++ b/requirements/requirements_dev.in
@@ -6,3 +6,4 @@ Django
 pip-tools
 pytest-django
 coverage
+django-markdown-deux

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -6,8 +6,10 @@
 #
 click==5.1                # via pip-tools
 coverage==3.7.1
+django-markdown-deux==1.0.5
 django==1.8.4
 first==2.0.1              # via pip-tools
+markdown2==2.3.0          # via django-markdown-deux
 pip-tools==1.1.4
 py==1.4.30                # via pytest
 pytest-django==2.8.0

--- a/requirements/requirements_prod.in
+++ b/requirements/requirements_prod.in
@@ -7,3 +7,4 @@ dj-static
 gunicorn
 psycopg2
 static
+django-markdown-deux

--- a/requirements/requirements_prod.txt
+++ b/requirements/requirements_prod.txt
@@ -6,8 +6,10 @@
 #
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-markdown-deux==1.0.5
 django==1.8.4
 gunicorn==19.3.0
+markdown2==2.3.0          # via django-markdown-deux
 psycopg2==2.6.1
 pystache==0.5.4           # via static
 static3==0.6.1            # via dj-static

--- a/requirements/requirements_test.in
+++ b/requirements/requirements_test.in
@@ -5,3 +5,4 @@
 coverage
 Django
 pytest-django
+django-markdown-deux

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -5,7 +5,9 @@
 #    pip-compile requirements_test.in
 #
 coverage==3.7.1
+django-markdown-deux==1.0.5
 django==1.8.4
+markdown2==2.3.0          # via django-markdown-deux
 py==1.4.30                # via pytest
 pytest-django==2.8.0
 pytest==2.7.2             # via pytest-django


### PR DESCRIPTION
This adds markdown template tags for the blog with the python-markdown2 package.  
Closes #55
