### PR TITLE
conform to pep8 guidelines

### DIFF
--- a/contributr/contriblog/admin.py
+++ b/contributr/contriblog/admin.py
@@ -4,7 +4,7 @@ from .models import Post
 
 
 class PostAdmin(admin.ModelAdmin):
-    prepopulated_fields = {'slug':('title',)}
+    prepopulated_fields = {'slug': ('title',)}
     list_display = ('title', 'author', 'created_date',)
 
 

--- a/contributr/contriblog/tests/test_blog.py
+++ b/contributr/contriblog/tests/test_blog.py
@@ -17,6 +17,7 @@ def test_call_blog(client):
     response = client.get(reverse("blog:index"))
     assert response.status_code == 200
 
+
 @pytest.mark.django_db
 def test_call_blog_subpage(client):
     """
@@ -36,12 +37,13 @@ def test_blog_model():
     Then assert that number of blog posts equals 1.
     """
     user = get_user_model().objects.create(username="bloghero")
-    post = Post(title="Test title blog", author=user, body="Blogging here!", publish=False)
+    post = Post(title="Test title blog", author=user,
+                body="Blogging here!", publish=False)
     post.save()
     assert Post.objects.all().count() == 1
 
     """
-    Assert that the custom queryset displays posts that has publish 
+    Assert that the custom queryset displays posts that has publish
     set to true.
     """
     assert Post.objects.published().count() == 0
@@ -50,7 +52,7 @@ def test_blog_model():
     assert Post.objects.published().count() == 1
 
     """
-    Asserts wether the post string representation (__str__) is equal 
+    Asserts wether the post string representation (__str__) is equal
     to the blog title.
     """
     assert str(post) == "Test title blog"

--- a/contributr/contributr/tests/test_admin.py
+++ b/contributr/contributr/tests/test_admin.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.django_db
 def test_welcome_django(admin_client):
     """
@@ -11,4 +12,3 @@ def test_welcome_django(admin_client):
     """
     response = admin_client.get("http://localhost:8000/admin/")
     assert response.status_code == 200
-

--- a/contributr/contributr/tests/test_views.py
+++ b/contributr/contributr/tests/test_views.py
@@ -1,13 +1,13 @@
 import pytest
 
+
 @pytest.mark.django_db
 def test_welcome_django(client):
     """
     Asserts whether the base URL 200s
 
-    200 means that the HTTP request was successful and 
+    200 means that the HTTP request was successful and
     that the frontpage exists.
     """
     response = client.get("http://localhost:8000/")
     assert response.status_code == 200
-

--- a/contributr/contributr/urls.py
+++ b/contributr/contributr/urls.py
@@ -18,7 +18,8 @@ from django.contrib import admin
 from django.views.generic import TemplateView
 
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name='contributr/index.html'), name="home"),
+    url(r'^$', TemplateView.as_view(
+        template_name='contributr/index.html'), name="home"),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^blog/', include("contriblog.urls", namespace="blog"))
 ]


### PR DESCRIPTION
the pep8 tool https://github.com/PyCQA/pep8 was used to conform
with pep8, the official code style guide for python.

https://www.python.org/dev/peps/pep-0008/

Note: People who contribute code should be also use the `pep8` tool to check for pep8 issues.

This is the current output of `pep8`:

``` shell
❯ pep8 .        
./contributr/manage.py:6:80: E501 line too long (80 > 79 characters)
./contributr/contributr/wsgi.py:14:80: E501 line too long (80 > 79 characters)
./contributr/contriblog/models.py:6:80: E501 line too long (81 > 79 characters)
./contributr/contriblog/migrations/0001_initial.py:18:80: E501 line too long (114 > 79 characters)
```

We can ignore the above errors for the sake of readability.
