### PR TITLE
move local database settings from base settings to local settings

### DIFF
--- a/contributr/contributr/settings/base.py
+++ b/contributr/contributr/settings/base.py
@@ -81,17 +81,6 @@ TEMPLATES = [
 WSGI_APPLICATION = 'contributr.wsgi.application'
 
 
-# Database
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
-
-
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 

--- a/contributr/contributr/settings/local.py
+++ b/contributr/contributr/settings/local.py
@@ -3,4 +3,14 @@
 
 from .base import *
 
+# Database
+# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
 DEBUG = True

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -5,7 +5,7 @@
 #    pip-compile requirements_dev.in
 #
 click==5.1                # via pip-tools
-coverage==3.7.1
+coverage==4.0
 django-markdown-deux==1.0.5
 django==1.8.4
 first==2.0.1              # via pip-tools
@@ -13,5 +13,5 @@ markdown2==2.3.0          # via django-markdown-deux
 pip-tools==1.1.4
 py==1.4.30                # via pytest
 pytest-django==2.8.0
-pytest==2.7.3             # via pytest-django
+pytest==2.8.0             # via pytest-django
 six==1.9.0                # via pip-tools

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -4,10 +4,10 @@
 #
 #    pip-compile requirements_test.in
 #
-coverage==3.7.1
+coverage==4.0
 django-markdown-deux==1.0.5
 django==1.8.4
 markdown2==2.3.0          # via django-markdown-deux
 py==1.4.30                # via pytest
 pytest-django==2.8.0
-pytest==2.7.3             # via pytest-django
+pytest==2.8.0             # via pytest-django


### PR DESCRIPTION
database settings are environment agnostic. They are different for
local and production environments. It makes more sense to have the
local database settings in the local settings file and use that
during development.
