### PR TITLE
Add account authentication with GitHub

### DIFF
--- a/contributr/contributr/settings/base.py
+++ b/contributr/contributr/settings/base.py
@@ -39,8 +39,13 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
 
     # Third party applications
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.github',
     'markdown_deux',
 
     # Project applications
@@ -106,3 +111,14 @@ STATIC_ROOT = 'staticfiles'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
+
+AUTHENTICATION_BACKENDS = (
+    # Needed to login by username in Django admin.
+    'django.contrib.auth.backends.ModelBackend',
+
+    # django-allauth specific authentication methods, such as login by e-mail.
+    'allauth.account.auth_backends.AuthenticationBackend',
+)
+
+# Site ID. This is required by django-allauth
+SITE_ID = 1

--- a/contributr/contributr/templates/base.html
+++ b/contributr/contributr/templates/base.html
@@ -43,6 +43,15 @@
             <li><a href="{%url 'blog:index' %}">Blog</a></li>
             <li><a href="https://github.com/Djenesis/contributr">GitHub</a></li>
           </ul>
+          <ul class="nav navbar-nav navbar-right">
+            <li>
+                {% if request.user.is_authenticated %}
+                <a href="/accounts/profile/"><span class="glyphicon glyphicon-user"></span> Profile</a></li>
+                {% else %}
+                <a href="/accounts/github/login/?process=login"><span class="glyphicon glyphicon-log-in"></span> Log in with GitHub</a>
+                {% endif %}
+            </li>
+          </ul>
         </div><!--/.navbar-collapse -->
       </div>
     </nav>

--- a/contributr/contributr/templates/contributr/profile.html
+++ b/contributr/contributr/templates/contributr/profile.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-10">
+    <h1>User profile</h1>
+    {% if request.user.is_authenticated %}
+      {% for account in user.socialaccount_set.all %}
+        <p><img width="50" height="50" src="{{ account.get_avatar_url }}" /></p>
+        <p>Username: {{ account.extra_data.login }}</p>
+        <p>UID: <a href="{{ account.extra_data.link }}">{{ account.uid }}</a></p>
+        <p>Name: {{ account.extra_data.name }}</p>
+        <p>Github url: {{ account.extra_data.html_url }}
+          <p>Location: {{ account.extra_data.location }}</p>
+          <p>Number of public repos: {{ account.extra_data.public_repos }}</p>
+          <p>Number of followers: {{ account.extra_data.followers }}</p>
+        {% endfor %}
+      </div>
+      
+      <div class="col-md-2">
+        <a href="{% url 'account_logout' %}" class="btn btn-default btn-default"><span class="glyphicon glyphicon-log-out"></span> Log out</a>
+      </div>
+    {% else %}
+      <p>You are not logged in.</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/contributr/contributr/urls.py
+++ b/contributr/contributr/urls.py
@@ -21,5 +21,10 @@ urlpatterns = [
     url(r'^$', TemplateView.as_view(
         template_name='contributr/index.html'), name="home"),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^blog/', include("contriblog.urls", namespace="blog"))
+    url(r'^blog/', include("contriblog.urls", namespace="blog")),
+
+    # django-allauth urls.
+    url(r'^accounts/', include('allauth.urls')),
+    url(r'^accounts/profile/', TemplateView.as_view(
+        template_name='contributr/profile.html'), name="profile"),
 ]

--- a/requirements/requirements_dev.in
+++ b/requirements/requirements_dev.in
@@ -7,3 +7,4 @@ pip-tools
 pytest-django
 coverage
 django-markdown-deux
+django-allauth

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -6,12 +6,18 @@
 #
 click==5.1                # via pip-tools
 coverage==4.0
+defusedxml==0.4.1         # via python3-openid
+django-allauth==0.23.0
 django-markdown-deux==1.0.5
 django==1.8.4
 first==2.0.1              # via pip-tools
 markdown2==2.3.0          # via django-markdown-deux
+oauthlib==1.0.3           # via requests-oauthlib
 pip-tools==1.1.4
 py==1.4.30                # via pytest
 pytest-django==2.8.0
 pytest==2.8.0             # via pytest-django
+python3-openid==3.0.7     # via django-allauth
+requests-oauthlib==0.5.0  # via django-allauth
+requests==2.7.0           # via django-allauth, requests-oauthlib
 six==1.9.0                # via pip-tools

--- a/requirements/requirements_prod.in
+++ b/requirements/requirements_prod.in
@@ -8,3 +8,4 @@ gunicorn
 psycopg2
 static
 django-markdown-deux
+django-allauth

--- a/requirements/requirements_prod.txt
+++ b/requirements/requirements_prod.txt
@@ -4,13 +4,19 @@
 #
 #    pip-compile requirements_prod.in
 #
+defusedxml==0.4.1         # via python3-openid
 dj-database-url==0.3.0
 dj-static==0.0.6
+django-allauth==0.23.0
 django-markdown-deux==1.0.5
 django==1.8.4
 gunicorn==19.3.0
 markdown2==2.3.0          # via django-markdown-deux
+oauthlib==1.0.3           # via requests-oauthlib
 psycopg2==2.6.1
 pystache==0.5.4           # via static
+python3-openid==3.0.7     # via django-allauth
+requests-oauthlib==0.5.0  # via django-allauth
+requests==2.7.0           # via django-allauth, requests-oauthlib
 static3==0.6.1            # via dj-static
 static==1.1.1

--- a/requirements/requirements_test.in
+++ b/requirements/requirements_test.in
@@ -6,3 +6,4 @@ coverage
 Django
 pytest-django
 django-markdown-deux
+django-allauth

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -5,9 +5,15 @@
 #    pip-compile requirements_test.in
 #
 coverage==4.0
+defusedxml==0.4.1         # via python3-openid
+django-allauth==0.23.0
 django-markdown-deux==1.0.5
 django==1.8.4
 markdown2==2.3.0          # via django-markdown-deux
+oauthlib==1.0.3           # via requests-oauthlib
 py==1.4.30                # via pytest
 pytest-django==2.8.0
 pytest==2.8.0             # via pytest-django
+python3-openid==3.0.7     # via django-allauth
+requests-oauthlib==0.5.0  # via django-allauth
+requests==2.7.0           # via django-allauth, requests-oauthlib


### PR DESCRIPTION
This adds support for OAuth2 authentication with GitHub using the django-allauth package.
- django-allauth in requirements files.
- Added django-allauth urls, with a custom profile url and template which displays github data.
- Added django-allauth specific settings in base.py.
- Added a link to login with GitHub to base.html navbar.

To get this working in development you need to register an app with GitHub:
https://github.com/settings/applications/new
Homepage url and callback url can be set to http://127.0.0.1:8000

Then in the Django Admin:
Set the example.com site to http:/127.0.0.1:8000
Social accounts > Add social application >
Provider: GitHub, Name: github. Add client key and secret key from registered app on GitHub. Key can be left blank. Set site to http://127.0.0.1:8000

Closes: #43
See also: #39
