### PR TITLE
use whitenoise to serve static files in production

### DIFF
--- a/contributr/contributr/settings/production.py
+++ b/contributr/contributr/settings/production.py
@@ -15,5 +15,9 @@ ALLOWED_HOSTS = ['*']
 
 DEBUG = True
 
+# Simplified static file serving using whitenoise.
+# https://warehouse.python.org/project/whitenoise/
+STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+
 # Allow https protocol to be used with callback urls in allauth
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"

--- a/contributr/contributr/wsgi.py
+++ b/contributr/contributr/wsgi.py
@@ -12,10 +12,10 @@ import os
 from django.core.wsgi import get_wsgi_application
 
 if os.environ.get("DJANGO_SETTINGS_MODULE") == "contributr.settings.production":
-    # Cling is a simple way of serving static assets.
-    # http://www.kennethreitz.org/essays/introducing-dj-static
-    from dj_static import Cling
-    application = Cling(get_wsgi_application())
+
+    # Using whitenoise to serve static files in production
+    from whitenoise.django import DjangoWhiteNoise
+    application = DjangoWhiteNoise(get_wsgi_application())
 else:
     application = get_wsgi_application()
 

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -16,7 +16,7 @@ oauthlib==1.0.3           # via requests-oauthlib
 pip-tools==1.1.4
 py==1.4.30                # via pytest
 pytest-django==2.8.0
-pytest==2.8.0             # via pytest-django
+pytest==2.8.1             # via pytest-django
 python3-openid==3.0.7     # via django-allauth
 requests-oauthlib==0.5.0  # via django-allauth
 requests==2.7.0           # via django-allauth, requests-oauthlib

--- a/requirements/requirements_prod.in
+++ b/requirements/requirements_prod.in
@@ -3,9 +3,9 @@
 
 Django
 dj-database-url
-dj-static
 gunicorn
 psycopg2
 static
 django-markdown-deux
 django-allauth
+whitenoise

--- a/requirements/requirements_prod.txt
+++ b/requirements/requirements_prod.txt
@@ -6,7 +6,6 @@
 #
 defusedxml==0.4.1         # via python3-openid
 dj-database-url==0.3.0
-dj-static==0.0.6
 django-allauth==0.23.0
 django-markdown-deux==1.0.5
 django==1.8.4
@@ -18,5 +17,5 @@ pystache==0.5.4           # via static
 python3-openid==3.0.7     # via django-allauth
 requests-oauthlib==0.5.0  # via django-allauth
 requests==2.7.0           # via django-allauth, requests-oauthlib
-static3==0.6.1            # via dj-static
 static==1.1.1
+whitenoise==2.0.4

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -13,7 +13,7 @@ markdown2==2.3.0          # via django-markdown-deux
 oauthlib==1.0.3           # via requests-oauthlib
 py==1.4.30                # via pytest
 pytest-django==2.8.0
-pytest==2.8.0             # via pytest-django
+pytest==2.8.1             # via pytest-django
 python3-openid==3.0.7     # via django-allauth
 requests-oauthlib==0.5.0  # via django-allauth
 requests==2.7.0           # via django-allauth, requests-oauthlib


### PR DESCRIPTION
django itself doesnt allow static file serving, so whitenoise is
used. whitenoise is only run during production in
settings.production and wsgi.py.

whitenoise can be tested in production by :
python manage.py collectstatic --dry-run --noinput

The old way of using Cling() and dj_static is removed.

whitenoise is added to production requirements and dj_static
is removed.

requirements are updated.
